### PR TITLE
Add Timestamp to ExceptionAggregate

### DIFF
--- a/src/main/scala/com/soundcloud/periskop/client/ExceptionAggregate.scala
+++ b/src/main/scala/com/soundcloud/periskop/client/ExceptionAggregate.scala
@@ -1,12 +1,15 @@
 package com.soundcloud.periskop.client
 
+import java.time.ZonedDateTime
+
 import scala.collection.immutable.Queue
 
 private[client] case class ExceptionAggregate
 (
   totalCount: Long = 0,
   severity: Severity = Severity.Error ,
-  latestExceptions: Queue[ExceptionWithContext] = Queue.empty
+  latestExceptions: Queue[ExceptionWithContext] = Queue.empty,
+  timestamp: ZonedDateTime = ZonedDateTime.now()
 ) {
     // limit memory consumption keep only N exceptions per aggregation key
     val maxExceptions = 10

--- a/src/main/scala/com/soundcloud/periskop/client/ExceptionAggregate.scala
+++ b/src/main/scala/com/soundcloud/periskop/client/ExceptionAggregate.scala
@@ -9,7 +9,7 @@ private[client] case class ExceptionAggregate
   totalCount: Long = 0,
   severity: Severity = Severity.Error ,
   latestExceptions: Queue[ExceptionWithContext] = Queue.empty,
-  timestamp: ZonedDateTime = ZonedDateTime.now()
+  createdAt: ZonedDateTime = ZonedDateTime.now()
 ) {
     // limit memory consumption keep only N exceptions per aggregation key
     val maxExceptions = 10

--- a/src/main/scala/com/soundcloud/periskop/client/ExceptionExporter.scala
+++ b/src/main/scala/com/soundcloud/periskop/client/ExceptionExporter.scala
@@ -49,6 +49,7 @@ class ExceptionExporter(exceptionCollector: ExceptionCollector) {
     "aggregation_key" -> aggregate.aggregationKey,
     "total_count" -> aggregate.totalCount,
     "severity" -> Severity.toString(aggregate.severity),
+    "timestamp" -> aggregate.timestamp.format(rfc3339TimeFormat),
     "latest_errors" -> aggregate.latestExceptions.map(jsonErrorWithContext)
   )
 

--- a/src/main/scala/com/soundcloud/periskop/client/ExceptionExporter.scala
+++ b/src/main/scala/com/soundcloud/periskop/client/ExceptionExporter.scala
@@ -49,7 +49,7 @@ class ExceptionExporter(exceptionCollector: ExceptionCollector) {
     "aggregation_key" -> aggregate.aggregationKey,
     "total_count" -> aggregate.totalCount,
     "severity" -> Severity.toString(aggregate.severity),
-    "timestamp" -> aggregate.timestamp.format(rfc3339TimeFormat),
+    "createdAt" -> aggregate.createdAt.format(rfc3339TimeFormat),
     "latest_errors" -> aggregate.latestExceptions.map(jsonErrorWithContext)
   )
 

--- a/src/test/scala/com/soundcloud/periskop/client/ExceptionExporterSpec.scala
+++ b/src/test/scala/com/soundcloud/periskop/client/ExceptionExporterSpec.scala
@@ -36,6 +36,7 @@ class ExceptionExporterSpec extends Specification with Mockito {
       ExceptionAggregate(
         totalCount = 3,
         severity = Severity.Error,
+        timestamp = timestamp1,
         latestExceptions = Queue(
           ExceptionWithContext(
             throwable = new FakeException("foo1", new FakeException("foo1parent")),
@@ -79,6 +80,7 @@ class ExceptionExporterSpec extends Specification with Mockito {
       ExceptionAggregate(
         totalCount = 1,
         severity = Severity.Error,
+        timestamp = timestamp1,
         latestExceptions = Queue(
           ExceptionWithContext(
             throwable = new FakeException("bar1", stackTraceLine = 42),
@@ -103,6 +105,7 @@ class ExceptionExporterSpec extends Specification with Mockito {
           |      "aggregation_key": "com.soundcloud.periskop.client.ExceptionExporterSpec$$FakeException@be63351f",
           |      "total_count": 3,
           |      "severity": "error",
+          |      "timestamp": "2018-01-02T11:22:33.000Z",
           |      "latest_errors": [
           |        {
           |          "error": {
@@ -187,6 +190,7 @@ class ExceptionExporterSpec extends Specification with Mockito {
           |      "aggregation_key": "com.soundcloud.periskop.client.ExceptionExporterSpec$$FakeException@a3f533f8",
           |      "total_count": 1,
           |      "severity": "error",
+          |      "timestamp": "2018-01-02T11:22:33.000Z",
           |      "latest_errors": [
           |        {
           |          "error": {

--- a/src/test/scala/com/soundcloud/periskop/client/ExceptionExporterSpec.scala
+++ b/src/test/scala/com/soundcloud/periskop/client/ExceptionExporterSpec.scala
@@ -36,7 +36,7 @@ class ExceptionExporterSpec extends Specification with Mockito {
       ExceptionAggregate(
         totalCount = 3,
         severity = Severity.Error,
-        timestamp = timestamp1,
+        createdAt = timestamp1,
         latestExceptions = Queue(
           ExceptionWithContext(
             throwable = new FakeException("foo1", new FakeException("foo1parent")),
@@ -80,7 +80,7 @@ class ExceptionExporterSpec extends Specification with Mockito {
       ExceptionAggregate(
         totalCount = 1,
         severity = Severity.Error,
-        timestamp = timestamp1,
+        createdAt = timestamp1,
         latestExceptions = Queue(
           ExceptionWithContext(
             throwable = new FakeException("bar1", stackTraceLine = 42),
@@ -105,7 +105,7 @@ class ExceptionExporterSpec extends Specification with Mockito {
           |      "aggregation_key": "com.soundcloud.periskop.client.ExceptionExporterSpec$$FakeException@be63351f",
           |      "total_count": 3,
           |      "severity": "error",
-          |      "timestamp": "2018-01-02T11:22:33.000Z",
+          |      "createdAt": "2018-01-02T11:22:33.000Z",
           |      "latest_errors": [
           |        {
           |          "error": {
@@ -190,7 +190,7 @@ class ExceptionExporterSpec extends Specification with Mockito {
           |      "aggregation_key": "com.soundcloud.periskop.client.ExceptionExporterSpec$$FakeException@a3f533f8",
           |      "total_count": 1,
           |      "severity": "error",
-          |      "timestamp": "2018-01-02T11:22:33.000Z",
+          |      "createdAt": "2018-01-02T11:22:33.000Z",
           |      "latest_errors": [
           |        {
           |          "error": {


### PR DESCRIPTION
Adding a timestamp to ExceptionAggregate in order to track when an error is seen for the first time