### PR TITLE
Enable linting + fatal warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,13 @@ lazy val scala213 = "2.13.4"
 val versions = new {
   val specs2 = "4.7.0"
   val jackson = "2.10.1"
+  val collectionCompat = "2.3.0"
 }
 
 name := "periskop-scala"
 
 libraryDependencies ++= Seq(
+  "org.scala-lang.modules" %% "scala-collection-compat" % versions.collectionCompat,
   "com.fasterxml.jackson.core" % "jackson-databind" % versions.jackson,
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % versions.jackson,
   "org.specs2" %% "specs2-core" % versions.specs2 % "test",
@@ -16,6 +18,19 @@ libraryDependencies ++= Seq(
 )
 crossScalaVersions := Seq(scala212, scala213)
 scalaVersion := scala213
+
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-encoding",
+  "UTF-8",
+  "-explaintypes",
+  "-feature",
+  "-unchecked",
+  "-Xfatal-warnings",
+  "-Xlint",
+  "-Ywarn-dead-code",
+  "-Ywarn-value-discard"
+)
 
 // publishing to maven central
 ThisBuild / organization := "com.soundcloud"

--- a/src/main/scala/com/soundcloud/periskop/client/ExceptionCollector.scala
+++ b/src/main/scala/com/soundcloud/periskop/client/ExceptionCollector.scala
@@ -2,7 +2,7 @@ package com.soundcloud.periskop.client
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.BiFunction
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ExceptionCollector {
   private val exceptions = new ConcurrentHashMap[String, ExceptionAggregate]

--- a/src/test/scala/com/soundcloud/periskop/client/ExceptionWithContextSpec.scala
+++ b/src/test/scala/com/soundcloud/periskop/client/ExceptionWithContextSpec.scala
@@ -18,7 +18,8 @@ class ExceptionWithContextSpec extends Specification {
   }
 
   "aggregationKey is based on the class name and stacktrace only" in new Context {
-    val Array(e1, e2) = Array(1, 2).map { i => new RuntimeException(s"foo $i") }
+    val eArr = Array(1, 2).map { i => new RuntimeException(s"foo $i") }
+    val (e1, e2) = (eArr(0), eArr(1))
     val e3: Throwable = new RuntimeException("foo 2")
 
     // do not match on exact string, backtrace hash changes when we change code


### PR DESCRIPTION
To ensure we're following best practises, let's enable
several linting options of the compiler and make warnings fatal.

We need to use collections-compat to avoid deprecation warnings for the
old-style java collection converters in 2.13.

One spec needed to be modified to avoid a non-exhaustive pattern match warning.