### PR TITLE
Run cross-tests on CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,5 +13,5 @@ test_task:
     folder: $HOME/.sbt/boot
     fingerprint_script: cat project/build.properties
     populate_script: sbt update
-  test_script: sbt test
+  test_script: sbt +test
 


### PR DESCRIPTION
Run tests for all scala versions on CI, not just the default one.
Previously we wouldn't test scala 2.12 at all on CI.