### PR TITLE
Convert created at field to snake case

### DIFF
--- a/src/main/scala/com/soundcloud/periskop/client/ExceptionExporter.scala
+++ b/src/main/scala/com/soundcloud/periskop/client/ExceptionExporter.scala
@@ -49,7 +49,7 @@ class ExceptionExporter(exceptionCollector: ExceptionCollector) {
     "aggregation_key" -> aggregate.aggregationKey,
     "total_count" -> aggregate.totalCount,
     "severity" -> Severity.toString(aggregate.severity),
-    "createdAt" -> aggregate.createdAt.format(rfc3339TimeFormat),
+    "created_at" -> aggregate.createdAt.format(rfc3339TimeFormat),
     "latest_errors" -> aggregate.latestExceptions.map(jsonErrorWithContext)
   )
 

--- a/src/test/scala/com/soundcloud/periskop/client/ExceptionExporterSpec.scala
+++ b/src/test/scala/com/soundcloud/periskop/client/ExceptionExporterSpec.scala
@@ -103,7 +103,7 @@ class ExceptionExporterSpec extends Specification with Mockito {
           |      "aggregation_key": "${exceptionAggregates(0).latestExceptions.head.aggregationKey}",
           |      "total_count": 3,
           |      "severity": "error",
-          |      "createdAt": "2018-01-02T11:22:33.000Z",
+          |      "created_at": "2018-01-02T11:22:33.000Z",
           |      "latest_errors": [
           |        {
           |          "error": {
@@ -188,7 +188,7 @@ class ExceptionExporterSpec extends Specification with Mockito {
           |      "aggregation_key": "${exceptionAggregates(1).latestExceptions.head.aggregationKey}",
           |      "total_count": 1,
           |      "severity": "error",
-          |      "createdAt": "2018-01-02T11:22:33.000Z",
+          |      "created_at": "2018-01-02T11:22:33.000Z",
           |      "latest_errors": [
           |        {
           |          "error": {


### PR DESCRIPTION
Rest of the fields are in snake case. This PR aims to convert `createdAt` to snake case to follow the convention.