### PR TITLE
Expose target UUID

### DIFF
--- a/src/main/scala/com/soundcloud/periskop/client/ExceptionCollector.scala
+++ b/src/main/scala/com/soundcloud/periskop/client/ExceptionCollector.scala
@@ -3,9 +3,11 @@ package com.soundcloud.periskop.client
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.BiFunction
 import scala.jdk.CollectionConverters._
+import java.util.UUID
 
 class ExceptionCollector {
   private val exceptions = new ConcurrentHashMap[String, ExceptionAggregate]
+  val uuid = UUID.randomUUID
 
   /** Collect an exception without providing an HTTP context.
     */

--- a/src/main/scala/com/soundcloud/periskop/client/ExceptionExporter.scala
+++ b/src/main/scala/com/soundcloud/periskop/client/ExceptionExporter.scala
@@ -66,7 +66,8 @@ class ExceptionExporter(exceptionCollector: ExceptionCollector) {
   )
 
   private def jsonResult(exceptionAggregates: Seq[ExceptionAggregate]): Map[String, Any] = Map(
-    "aggregated_errors" -> exceptionAggregates.map(jsonAggregatedErrors)
+    "aggregated_errors" -> exceptionAggregates.map(jsonAggregatedErrors),
+    "target_uuid" -> exceptionCollector.uuid
   )
 
 }

--- a/src/test/scala/com/soundcloud/periskop/client/ExceptionExporterSpec.scala
+++ b/src/test/scala/com/soundcloud/periskop/client/ExceptionExporterSpec.scala
@@ -109,12 +109,15 @@ class ExceptionExporterSpec extends Specification with Mockito {
     )
 
     val collector = smartMock[ExceptionCollector]
+    val targetUuid = UUID.randomUUID()
     when(collector.getExceptionAggregates).thenReturn(exceptionAggregates)
+    when(collector.uuid).thenReturn(targetUuid)
 
     val exporter = new ExceptionExporter(collector)
 
     parseJson(exporter.export) ==== parseJson(
       s"""|{
+          | "target_uuid": "$targetUuid",
           |  "aggregated_errors": [
           |    {
           |      "aggregation_key": "${exceptionAggregates(0).latestExceptions.head.aggregationKey}",


### PR DESCRIPTION
  - Exposing a UUID per target collector is necessary to avoid
    collisions which may result in wrong counters.
  - See https://github.com/soundcloud/periskop/issues/169
 